### PR TITLE
Prebid.js v5 必須パラメーターの meta.advertiserDomains を返すように修正

### DIFF
--- a/modules/open8BidAdapter.js
+++ b/modules/open8BidAdapter.js
@@ -1,8 +1,8 @@
-import { Renderer } from 'src/Renderer';
-import {ajax} from '../src/ajax';
-import * as utils from 'src/utils';
-import { registerBidder } from 'src/adapters/bidderFactory';
-import { VIDEO, BANNER } from 'src/mediaTypes';
+import { Renderer } from '../src/Renderer.js';
+import {ajax} from '../src/ajax.js';
+import * as utils from '../src/utils.js';
+import { registerBidder } from '../src/adapters/bidderFactory.js';
+import { VIDEO, BANNER } from '../src/mediaTypes.js';
 
 const BIDDER_CODE = 'open8';
 const URL = '//as.vt.open8.com/v1/control/prebid';
@@ -65,6 +65,9 @@ export const spec = {
       currency: ad.currency || 'JPY',
       netRevenue: true,
       ttl: 360, // 6 minutes
+      meta: {
+        advertiserDomains: ad.adomain || []
+      }
     }
 
     if (ad.adType === AD_TYPE.VIDEO) {

--- a/test/spec/modules/open8BidAdapter_spec.js
+++ b/test/spec/modules/open8BidAdapter_spec.js
@@ -53,6 +53,7 @@ describe('Open8Adapter', function() {
     });
   });
   describe('interpretResponse', function() {
+    const adomin = ['example.com']
     const bannerResponse = {
       slotKey: 'slotkey1234',
       userId: 'userid1234',
@@ -80,7 +81,8 @@ describe('Open8Adapter', function() {
           h: 250,
           adm: '<div></div>',
           imps: ['//example.com/imp']
-        }
+        },
+        adomain: adomin
       }
     };
     const videoResponse = {
@@ -110,6 +112,7 @@ describe('Open8Adapter', function() {
           w: 320,
           h: 180
         },
+        adomain: adomin
       }
     };
 
@@ -135,12 +138,14 @@ describe('Open8Adapter', function() {
         'mediaType': 'banner',
         'currency': 'JPY',
         'ttl': 360,
-        'netRevenue': true
+        'netRevenue': true,
+        'meta': { }
       }];
 
       let bidderRequest;
       let result = spec.interpretResponse({ body: bannerResponse }, { bidderRequest });
       expect(Object.keys(result[0])).to.have.members(Object.keys(expectedResponse[0]));
+      expect(result[0]).to.nested.contain.property('meta.advertiserDomains', adomin);
     });
 
     it('handles video responses', function() {
@@ -167,12 +172,14 @@ describe('Open8Adapter', function() {
         'adResponse': {},
         'currency': 'JPY',
         'ttl': 360,
-        'netRevenue': true
+        'netRevenue': true,
+        'meta': { }
       }];
 
       let bidderRequest;
       let result = spec.interpretResponse({ body: videoResponse }, { bidderRequest });
       expect(Object.keys(result[0])).to.have.members(Object.keys(expectedResponse[0]));
+      expect(result[0]).to.nested.contain.property('meta.advertiserDomains', adomin);
     });
 
     it('handles nobid responses', function() {


### PR DESCRIPTION
表題の通りです。この修正により Prebid.js に v5 準拠を告げることができます。